### PR TITLE
Implement user profile and password update functionality; add corresponding DTOs and controller methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "m:g": "node --require ts-node/register ./node_modules/typeorm/cli.js migration:generate src/migrations/Init -d \"src/data-source.ts\"",
+    "m:g": "node --require ts-node/register ./node_modules/typeorm/cli.js migration:generate -d \"src/data-source.ts\"",
     "m:c": "node --require ts-node/register ./node_modules/typeorm/cli.js migration:create",
     "m:run": "node --require ts-node/register ./node_modules/typeorm/cli.js migration:run -d \"src/data-source.ts\"",
     "m:revert": "node --require ts-node/register ./node_modules/typeorm/cli.js migration:revert -d \"src/data-source.ts\""

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
-import bcrypt from 'bcrypt';
+import * as bcrypt from 'bcrypt';
 import { RegisterDto } from './dto/register.dto';
 import { SignInDto } from './dto/signin.dto';
 import { User } from 'src/users/entities/user.entity';

--- a/src/common/constants/permissions-and-roles.ts
+++ b/src/common/constants/permissions-and-roles.ts
@@ -8,6 +8,7 @@ export const PERMISSIONS = {
   DELETE_COMMENT_OWN: 'delete_comment_own',
   DELETE_COMMENT_ANY: 'delete_comment_any',
   ASSIGN_ROLE: 'assign_role',
+  UPDATE_PROFILE_OWN: 'update_profile_own',
 };
 
 export const ROLES = {

--- a/src/common/interfaces/authenticated-request.ts
+++ b/src/common/interfaces/authenticated-request.ts
@@ -1,0 +1,22 @@
+import { Request } from 'express';
+
+export interface AuthenticatedRequest extends Request {
+  user: {
+    id: number;
+    email: string;
+    name: string;
+    bio?: string;
+    createdAt: Date;
+    updatedAt: Date;
+    roles: Array<{
+      id: number;
+      name: string;
+      description?: string;
+      permissions: Array<{
+        id: number;
+        name: string;
+        description?: string;
+      }>;
+    }>;
+  };
+}

--- a/src/seeds/seed-rbac.ts
+++ b/src/seeds/seed-rbac.ts
@@ -30,6 +30,7 @@ async function bootstrap() {
     PERMISSIONS.CREATE_COMMENT,
     PERMISSIONS.EDIT_COMMENT_OWN,
     PERMISSIONS.DELETE_COMMENT_OWN,
+    PERMISSIONS.UPDATE_PROFILE_OWN,
   ];
 
   const adminPermissionNames = [
@@ -38,6 +39,9 @@ async function bootstrap() {
     PERMISSIONS.CREATE_COMMENT,
     PERMISSIONS.DELETE_COMMENT_ANY,
     PERMISSIONS.ASSIGN_ROLE,
+    PERMISSIONS.UPDATE_PROFILE_OWN,
+    PERMISSIONS.EDIT_POST_OWN,
+    PERMISSIONS.EDIT_COMMENT_OWN,
   ];
 
   const app = await NestFactory.createApplicationContext(AppModule);

--- a/src/users/dto/password-update-response.dto.ts
+++ b/src/users/dto/password-update-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PasswordUpdateResponseDto {
+  @ApiProperty({
+    description: 'Success message confirming password update',
+    example: 'Password updated successfully',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'Timestamp of the password update',
+    example: '2025-09-03T10:15:30.123Z',
+  })
+  updatedAt: Date;
+}

--- a/src/users/dto/update-password.dto.ts
+++ b/src/users/dto/update-password.dto.ts
@@ -1,0 +1,15 @@
+import { IsString, MinLength, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdatePasswordDto {
+  @ApiProperty({
+    description: 'New password for the user account',
+    example: 'MyNewPassword123',
+    minLength: 6,
+    maxLength: 64,
+  })
+  @IsString()
+  @MinLength(6, { message: 'Password must be at least 6 characters long' })
+  @MaxLength(64, { message: 'Password must not exceed 64 characters' })
+  newPassword: string;
+}

--- a/src/users/dto/update-profile.dto.ts
+++ b/src/users/dto/update-profile.dto.ts
@@ -1,0 +1,26 @@
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateProfileDto {
+  @ApiPropertyOptional({
+    description: 'User full name',
+    example: 'John Doe',
+    minLength: 2,
+    maxLength: 50,
+  })
+  @IsOptional()
+  @IsString()
+  @MinLength(2, { message: 'Name must be at least 2 characters long' })
+  @MaxLength(50, { message: 'Name must not exceed 50 characters' })
+  name?: string;
+
+  @ApiPropertyOptional({
+    description: 'User biography or description',
+    example: 'Software developer passionate about clean code and technology',
+    maxLength: 500,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500, { message: 'Bio must not exceed 500 characters' })
+  bio?: string;
+}

--- a/src/users/dto/user-profile-response.dto.ts
+++ b/src/users/dto/user-profile-response.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserProfileResponseDto {
+  @ApiProperty({
+    description: 'User unique identifier',
+    example: 1,
+  })
+  id: number;
+
+  @ApiProperty({
+    description: 'User full name',
+    example: 'John Doe',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: 'User email address',
+    example: 'john.doe@example.com',
+  })
+  email: string;
+
+  @ApiProperty({
+    description: 'User biography or description',
+    example: 'Software developer passionate about clean code and technology',
+    nullable: true,
+  })
+  bio: string | null;
+
+  @ApiProperty({
+    description: 'Account creation timestamp',
+    example: '2025-09-01T12:34:56.789Z',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    description: 'Account last update timestamp',
+    example: '2025-09-03T10:15:30.123Z',
+  })
+  updatedAt: Date;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,161 @@
+import {
+  Controller,
+  Patch,
+  Body,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiUnauthorizedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+  ApiSecurity,
+} from '@nestjs/swagger';
+import { UsersService } from './users.service';
+import type { AuthenticatedRequest } from '../common/interfaces/authenticated-request';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { UpdatePasswordDto } from './dto/update-password.dto';
+import { UserProfileResponseDto } from './dto/user-profile-response.dto';
+import { PasswordUpdateResponseDto } from './dto/password-update-response.dto';
+import { AuthGuard } from '../auth/auth.guard';
+import { PermissionsGuard } from '../admin/guards/permissions.guard';
+import { RequirePermissions } from '../admin/decorators/require-permissions.decorator';
+import { PERMISSIONS } from '../common/constants/permissions-and-roles';
+
+@ApiTags('User Profile Management')
+@ApiSecurity('JWT-auth')
+@ApiBearerAuth('JWT-auth')
+@Controller('users/me')
+@UseGuards(AuthGuard, PermissionsGuard)
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Patch('profile')
+  @HttpCode(HttpStatus.OK)
+  @RequirePermissions(PERMISSIONS.UPDATE_PROFILE_OWN)
+  @ApiOperation({
+    summary: 'Update user profile',
+    description:
+      "Update the authenticated user's profile information (name and bio)",
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Profile updated successfully',
+    type: UserProfileResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid input data (validation errors)',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: [
+          'Name must be at least 2 characters long',
+          'Bio must not exceed 500 characters',
+        ],
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Authentication required',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: 'Unauthorized',
+      },
+    },
+  })
+  @ApiForbiddenResponse({
+    description: 'Insufficient permissions',
+    schema: {
+      example: {
+        statusCode: 403,
+        message: 'Forbidden resource',
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'User not found',
+        error: 'Not Found',
+      },
+    },
+  })
+  async updateProfile(
+    @Request() req: AuthenticatedRequest,
+    @Body() dto: UpdateProfileDto,
+  ): Promise<UserProfileResponseDto> {
+    return this.usersService.updateProfile(req.user.id, dto);
+  }
+
+  @Patch('password')
+  @HttpCode(HttpStatus.OK)
+  @RequirePermissions(PERMISSIONS.UPDATE_PROFILE_OWN)
+  @ApiOperation({
+    summary: 'Update user password',
+    description:
+      "Update the authenticated user's password with a new secure password",
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Password updated successfully',
+    type: PasswordUpdateResponseDto,
+  })
+  @ApiBadRequestResponse({
+    description: 'Invalid password format',
+    schema: {
+      example: {
+        statusCode: 400,
+        message: [
+          'Password must be at least 8 characters long',
+          'Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character',
+        ],
+        error: 'Bad Request',
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: 'Authentication required',
+    schema: {
+      example: {
+        statusCode: 401,
+        message: 'Unauthorized',
+      },
+    },
+  })
+  @ApiForbiddenResponse({
+    description: 'Insufficient permissions',
+    schema: {
+      example: {
+        statusCode: 403,
+        message: 'Forbidden resource',
+      },
+    },
+  })
+  @ApiNotFoundResponse({
+    description: 'User not found',
+    schema: {
+      example: {
+        statusCode: 404,
+        message: 'User not found',
+        error: 'Not Found',
+      },
+    },
+  })
+  async updatePassword(
+    @Request() req: AuthenticatedRequest,
+    @Body() dto: UpdatePasswordDto,
+  ): Promise<PasswordUpdateResponseDto> {
+    return this.usersService.updatePassword(req.user.id, dto);
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,12 +1,14 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
 import { User } from './entities/user.entity';
 import { Role } from 'src/roles/entities/role.entity';
 import { Permission } from 'src/permissions/entities/permission.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User, Role, Permission])],
+  controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -101,12 +101,7 @@ export class UsersService {
         throw new NotFoundException('User not found');
       }
 
-      console.log('Updating password for user:', user.email);
-      console.log('New password (plain):', dto.newPassword);
-
       const hashedPassword = await bcrypt.hash(dto.newPassword, 10);
-      console.log('Generated hash:', hashedPassword);
-      console.log('Hash starts with $2b$:', hashedPassword.startsWith('$2b$'));
 
       user.password = hashedPassword;
 

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -4,6 +4,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from './entities/user.entity';
 import { RegisterDto } from '../auth/dto/register.dto';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { UpdatePasswordDto } from './dto/update-password.dto';
 import * as bcrypt from 'bcrypt';
 import { Role } from '../roles/entities/role.entity';
 
@@ -62,6 +64,64 @@ export class UsersService {
       return user;
     } catch (error) {
       handleDatabaseError(error, 'fetch user by id');
+    }
+  }
+
+  async updateProfile(userId: number, dto: UpdateProfileDto): Promise<User> {
+    try {
+      const user = await this.userRepository.findOne({ where: { id: userId } });
+      if (!user) {
+        throw new NotFoundException('User not found');
+      }
+
+      // Only update fields that are provided
+      if (dto.name !== undefined) {
+        user.name = dto.name;
+      }
+      if (dto.bio !== undefined) {
+        user.bio = dto.bio;
+      }
+
+      return await this.userRepository.save(user);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      handleDatabaseError(error, 'update user profile');
+    }
+  }
+
+  async updatePassword(
+    userId: number,
+    dto: UpdatePasswordDto,
+  ): Promise<{ message: string; updatedAt: Date }> {
+    try {
+      const user = await this.userRepository.findOne({ where: { id: userId } });
+      if (!user) {
+        throw new NotFoundException('User not found');
+      }
+
+      console.log('Updating password for user:', user.email);
+      console.log('New password (plain):', dto.newPassword);
+
+      const hashedPassword = await bcrypt.hash(dto.newPassword, 10);
+      console.log('Generated hash:', hashedPassword);
+      console.log('Hash starts with $2b$:', hashedPassword.startsWith('$2b$'));
+
+      user.password = hashedPassword;
+
+      const updatedUser = await this.userRepository.save(user);
+      console.log('Password saved successfully');
+
+      return {
+        message: 'Password updated successfully',
+        updatedAt: updatedUser.updatedAt,
+      };
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      handleDatabaseError(error, 'update user password');
     }
   }
 }


### PR DESCRIPTION
This pull request introduces user profile self-management features, allowing authenticated users to update their own profile information and passwords. It adds new DTOs, controller endpoints, and service methods for these operations, and also updates the permissions system to support the new functionality. Additionally, it improves type safety and API documentation.

**User Profile and Password Update Features:**

* Added `UsersController` with two new endpoints under `users/me`:
  - `PATCH /users/me/profile` for updating the user's name and bio, requiring the `UPDATE_PROFILE_OWN` permission.
  - `PATCH /users/me/password` for updating the user's password, also requiring the `UPDATE_PROFILE_OWN` permission. [

* Implemented `updateProfile` and `updatePassword` methods in `UsersService` to handle profile and password updates, including validation, error handling, and password hashing. 

* Added DTOs for request and response validation and documentation:
  - `UpdateProfileDto` for profile updates.
  - `UpdatePasswordDto` for password updates.
  - `UserProfileResponseDto` and `PasswordUpdateResponseDto` for API responses. 
**Permissions and RBAC Updates:**

* Introduced new permission `UPDATE_PROFILE_OWN` in the permissions constants and assigned it to both user and admin roles in the RBAC seed script. 
**Type Safety and Dependency Improvements:**

* Added an `AuthenticatedRequest` interface to ensure strong typing of the authenticated user object in request handlers.
* Fixed the import style for `bcrypt` to avoid potential issues.

**Other Minor Changes:**

* Updated the `m:g` script in `package.json` to remove a default migration name, making it more flexible.