### PR TITLE
Add list posts functionality with pagination and search capabilities

### DIFF
--- a/src/common/constants/permissions-and-roles.ts
+++ b/src/common/constants/permissions-and-roles.ts
@@ -10,6 +10,7 @@ export const PERMISSIONS = {
   ASSIGN_ROLE: 'assign_role',
   UPDATE_PROFILE_OWN: 'update_profile_own',
   VIEW_USERS: 'view_users',
+  VIEW_POSTS: 'view_posts',
 };
 
 export const ROLES = {

--- a/src/posts/dto/create-post-response.dto.ts
+++ b/src/posts/dto/create-post-response.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { PostVisibility } from 'src/posts/enums/post-visibility.enum';
 
-export class PostResponseDto {
+export class CreatePostResponseDto {
   @ApiProperty({
     example: 1,
     description: 'Unique post identifier',

--- a/src/posts/dto/list-posts-response.dto.ts
+++ b/src/posts/dto/list-posts-response.dto.ts
@@ -1,0 +1,81 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PostVisibility } from '../enums/post-visibility.enum';
+
+export class PostListItemDto {
+  @ApiProperty({
+    example: 1,
+    description: 'Post ID',
+  })
+  id: number;
+
+  @ApiProperty({
+    example: 'My First Blog Post',
+    description: 'Post title',
+  })
+  title: string;
+
+  @ApiProperty({
+    example: PostVisibility.PUBLIC,
+    description: 'Post visibility setting',
+    enum: PostVisibility,
+  })
+  visibility: PostVisibility;
+
+  @ApiProperty({
+    example: 5,
+    description: 'Estimated time to read in minutes',
+  })
+  timeToRead: number;
+
+  @ApiProperty({
+    example: 1,
+    description: 'Author ID',
+  })
+  authorId: number;
+
+  @ApiProperty({
+    example: 'John Doe',
+    description: 'Author name',
+  })
+  authorName: string;
+
+  @ApiProperty({
+    example: '2025-09-07T12:34:56.789Z',
+    description: 'Post creation timestamp',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: '2025-09-07T12:34:56.789Z',
+    description: 'Post last update timestamp',
+  })
+  updatedAt: Date;
+}
+
+export class ListPostsResponseDto {
+  @ApiProperty({
+    type: [PostListItemDto],
+    description: 'List of posts',
+  })
+  posts: PostListItemDto[];
+
+  @ApiProperty({
+    description: 'Pagination metadata',
+    example: {
+      page: 1,
+      limit: 10,
+      total: 25,
+      totalPages: 3,
+      hasNextPage: true,
+      hasPrevPage: false,
+    },
+  })
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+    hasNextPage: boolean;
+    hasPrevPage: boolean;
+  };
+}

--- a/src/posts/dto/list-posts.dto.ts
+++ b/src/posts/dto/list-posts.dto.ts
@@ -1,0 +1,13 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+
+export class ListPostsDto extends PaginationDto {
+  @ApiPropertyOptional({
+    description: 'Search term to filter posts by title or content',
+    example: 'javascript',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+}

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,9 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Post } from './entities/post.entity';
 import { User } from '../users/entities/user.entity';
 import { CreatePostDto } from './dto/create-post.dto';
+import { ListPostsDto } from './dto/list-posts.dto';
+import {
+  PostListItemDto,
+  ListPostsResponseDto,
+} from './dto/list-posts-response.dto';
+import { PostVisibility } from './enums/post-visibility.enum';
 import { handleDatabaseError } from '../common/utils/handle-database-error';
 
 @Injectable()
@@ -26,5 +32,88 @@ export class PostsService {
     } catch (error) {
       handleDatabaseError(error, 'create post');
     }
+  }
+
+  async listPosts(
+    dto: ListPostsDto,
+    userId?: number,
+  ): Promise<ListPostsResponseDto> {
+    try {
+      const { page = 1, limit = 10, search } = dto;
+      const skip = (page - 1) * limit;
+
+      const queryBuilder = this.postsRepository
+        .createQueryBuilder('post')
+        .leftJoinAndSelect('post.author', 'author');
+
+      // show public posts + user's own private posts
+
+      queryBuilder.where(
+        '(post.visibility = :publicVisibility OR (post.visibility = :privateVisibility AND post.author.id = :userId))',
+        {
+          publicVisibility: PostVisibility.PUBLIC,
+          privateVisibility: PostVisibility.PRIVATE,
+          userId,
+        },
+      );
+
+      if (search) {
+        queryBuilder.andWhere(
+          '(post.title ILIKE :search OR post.content ILIKE :search)',
+          { search: `%${search}%` },
+        );
+      }
+
+      queryBuilder.orderBy('post.createdAt', 'DESC').skip(skip).take(limit);
+
+      const [posts, total] = await queryBuilder.getManyAndCount();
+
+      const totalPages = Math.ceil(total / limit) || 1;
+      // Validate that the requested page is within bounds
+      if (total > 0 && page > totalPages) {
+        throw new NotFoundException(
+          `Page ${page} not found. Total pages available: ${totalPages}`,
+        );
+      }
+      const hasNextPage = page < totalPages;
+      const hasPrevPage = page > 1;
+
+      const postItems: PostListItemDto[] = posts.map((post) => ({
+        id: post.id,
+        title: post.title,
+        visibility: post.visibility,
+        timeToRead: this.calculateTimeToRead(post.content),
+        authorId: post.author.id,
+        authorName: post.author.name,
+        createdAt: post.createdAt,
+        updatedAt: post.updatedAt,
+      }));
+
+      return {
+        posts: postItems,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages,
+          hasNextPage,
+          hasPrevPage,
+        },
+      };
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      handleDatabaseError(error, 'list posts');
+    }
+  }
+
+  private calculateTimeToRead(content: string): number {
+    // Average reading speed is about 200-250 words per minute
+    // We'll use 200 words per minute as a conservative estimate
+    const wordsPerMinute = 200;
+    const wordCount = content.trim().split(/\s+/).length;
+    const timeToRead = Math.max(1, Math.ceil(wordCount / wordsPerMinute));
+    return timeToRead;
   }
 }

--- a/src/seeds/seed-rbac.ts
+++ b/src/seeds/seed-rbac.ts
@@ -31,6 +31,7 @@ async function bootstrap() {
     PERMISSIONS.EDIT_COMMENT_OWN,
     PERMISSIONS.DELETE_COMMENT_OWN,
     PERMISSIONS.UPDATE_PROFILE_OWN,
+    PERMISSIONS.VIEW_POSTS,
   ];
 
   const adminPermissionNames = [
@@ -43,6 +44,7 @@ async function bootstrap() {
     PERMISSIONS.EDIT_POST_OWN,
     PERMISSIONS.EDIT_COMMENT_OWN,
     PERMISSIONS.VIEW_USERS,
+    PERMISSIONS.VIEW_POSTS,
   ];
 
   const app = await NestFactory.createApplicationContext(AppModule);


### PR DESCRIPTION
This pull request adds a new paginated "list posts" API endpoint, including DTOs, permissions, and service logic, allowing authenticated users to retrieve public posts as well as their own private posts. It also standardizes response DTO naming and improves RBAC seeding. The main changes are grouped below:

**New "List Posts" API Endpoint:**

* Added a `GET /posts` endpoint to `PostsController`, allowing authenticated users with the `VIEW_POSTS` permission to retrieve a paginated, searchable list of posts (public posts and their own private posts). The endpoint supports pagination and search query parameters and returns structured pagination metadata. 
* Implemented the corresponding service method `listPosts` in `PostsService`, including query building, filtering, pagination, and calculation of estimated reading time for each post.

**DTO and Response Structure Improvements:**

* Added `ListPostsDto` for query parameters and `ListPostsResponseDto`/`PostListItemDto` for the response structure, providing strong typing and Swagger documentation for the new endpoint. 
* Renamed `PostResponseDto` to `CreatePostResponseDto` for clarity and updated controller and imports accordingly. 

**Permissions and RBAC Updates:**

* Introduced a new `VIEW_POSTS` permission in `PERMISSIONS` constants and ensured it is seeded for both user and admin roles in the RBAC seeding script. 

These changes collectively enable secure, paginated post listing with search, while improving code clarity and RBAC consistency.