### PR TITLE
Implement refresh token functionality with DTOs, service methods, and controller endpoints

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,13 +1,16 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { AuthGuard } from './auth.guard';
 import { UsersModule } from 'src/users/users.module';
+import { RefreshToken } from './entities/refresh-token.entity';
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([RefreshToken]),
     UsersModule,
     JwtModule.registerAsync({
       global: true,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,23 +1,34 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThan, In } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
+import * as crypto from 'crypto';
 import { RegisterDto } from './dto/register.dto';
 import { SignInDto } from './dto/signin.dto';
+import { RefreshTokenDto } from './dto/refresh-token.dto';
+import { TokenResponseDto } from './dto/token-response.dto';
 import { User } from 'src/users/entities/user.entity';
+import { RefreshToken } from './entities/refresh-token.entity';
+import { handleDatabaseError } from '../common/utils/handle-database-error';
 
 @Injectable()
 export class AuthService {
   constructor(
     private usersService: UsersService,
     private jwtService: JwtService,
+    private configService: ConfigService,
+    @InjectRepository(RefreshToken)
+    private refreshTokenRepository: Repository<RefreshToken>,
   ) {}
 
   async register(data: RegisterDto): Promise<User> {
     return this.usersService.createUser(data);
   }
 
-  async signIn(signInDto: SignInDto): Promise<{ access_token: string }> {
+  async signIn(signInDto: SignInDto): Promise<TokenResponseDto> {
     const user = await this.usersService.findByEmailForAuth(signInDto.email);
     if (!user) {
       throw new UnauthorizedException('User not found');
@@ -29,9 +40,183 @@ export class AuthService {
     if (!passwordValid) {
       throw new UnauthorizedException('Invalid credentials');
     }
-    const payload = { sub: user.id, username: user.name };
-    return {
-      access_token: await this.jwtService.signAsync(payload),
-    };
+    return this.generateTokens(user);
+  }
+
+  async refreshTokens(
+    refreshTokenDto: RefreshTokenDto,
+  ): Promise<TokenResponseDto> {
+    try {
+      const refreshToken = await this.refreshTokenRepository.findOne({
+        where: {
+          token: refreshTokenDto.refreshToken,
+          isRevoked: false,
+          expiresAt: MoreThan(new Date()),
+        },
+        relations: ['user'],
+      });
+
+      if (!refreshToken) {
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+
+      // Revoke the used refresh token (token rotation)
+      refreshToken.isRevoked = true;
+      await this.refreshTokenRepository.save(refreshToken);
+
+      // Generate new tokens
+      const newTokens = await this.generateTokens(refreshToken.user);
+
+      return newTokens;
+    } catch (error) {
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
+      handleDatabaseError(error, 'refresh tokens');
+    }
+  }
+
+  async revokeRefreshToken(refreshTokenDto: RefreshTokenDto): Promise<void> {
+    try {
+      const refreshToken = await this.refreshTokenRepository.findOne({
+        where: { token: refreshTokenDto.refreshToken },
+      });
+
+      if (refreshToken) {
+        refreshToken.isRevoked = true;
+        await this.refreshTokenRepository.save(refreshToken);
+      }
+    } catch (error) {
+      handleDatabaseError(error, 'revoke refresh token');
+    }
+  }
+
+  private async generateTokens(user: User): Promise<TokenResponseDto> {
+    try {
+      const payload = { sub: user.id, username: user.name };
+      const accessToken = await this.jwtService.signAsync(payload);
+
+      // Generate refresh token
+      const refreshTokenValue = crypto.randomBytes(64).toString('hex');
+      const refreshTokenExpiresIn = this.configService.get<string>(
+        'REFRESH_TOKEN_EXPIRES_IN',
+        '7d',
+      );
+
+      // Parse the expiration time
+      const expiresAt = new Date();
+      const expirationMatch = refreshTokenExpiresIn.match(/^(\d+)([dhm])$/);
+      if (expirationMatch) {
+        const value = parseInt(expirationMatch[1]);
+        const unit = expirationMatch[2];
+        switch (unit) {
+          case 'd':
+            expiresAt.setDate(expiresAt.getDate() + value);
+            break;
+          case 'h':
+            expiresAt.setHours(expiresAt.getHours() + value);
+            break;
+          case 'm':
+            expiresAt.setMinutes(expiresAt.getMinutes() + value);
+            break;
+        }
+      } else {
+        // Default to 7 days if parsing fails
+        expiresAt.setDate(expiresAt.getDate() + 7);
+      }
+
+      // Limit concurrent refresh tokens per user
+      await this.limitConcurrentTokens(user.id);
+
+      // Save refresh token to database
+      const refreshTokenEntity = this.refreshTokenRepository.create({
+        token: refreshTokenValue,
+        user: { id: user.id } as User,
+        expiresAt,
+      });
+
+      await this.refreshTokenRepository.save(refreshTokenEntity);
+
+      // Get access token expiration from config
+      const accessTokenExpiresIn = this.configService.get<string>(
+        'JWT_EXPIRES_IN',
+        '15m',
+      );
+      const expiresInSeconds =
+        this.parseExpirationToSeconds(accessTokenExpiresIn);
+
+      return {
+        access_token: accessToken,
+        refresh_token: refreshTokenValue,
+        token_type: 'Bearer',
+        expires_in: expiresInSeconds,
+      };
+    } catch (error) {
+      handleDatabaseError(error, 'generate tokens');
+    }
+  }
+
+  private parseExpirationToSeconds(expiration: string): number {
+    const match = expiration.match(/^(\d+)([dhms])$/);
+    if (!match) return 900; // Default 15 minutes
+
+    const value = parseInt(match[1]);
+    const unit = match[2];
+
+    switch (unit) {
+      case 'd':
+        return value * 24 * 60 * 60;
+      case 'h':
+        return value * 60 * 60;
+      case 'm':
+        return value * 60;
+      case 's':
+        return value;
+      default:
+        return 900; // Default 15 minutes
+    }
+  }
+
+  // Cleanup expired tokens (can be called by a cron job)
+  async cleanupExpiredTokens(): Promise<number> {
+    try {
+      const result = await this.refreshTokenRepository.delete({
+        expiresAt: MoreThan(new Date()),
+      });
+      return result.affected || 0;
+    } catch (error) {
+      handleDatabaseError(error, 'cleanup expired tokens');
+      return 0;
+    }
+  }
+
+  // Limit concurrent refresh tokens per user
+  private async limitConcurrentTokens(userId: number): Promise<void> {
+    try {
+      const maxTokens = this.configService.get<number>(
+        'MAX_REFRESH_TOKENS_PER_USER',
+        5,
+      );
+
+      const tokenCount = await this.refreshTokenRepository.count({
+        where: { user: { id: userId }, isRevoked: false },
+      });
+
+      if (tokenCount >= maxTokens) {
+        // Remove oldest tokens
+        const oldestTokens = await this.refreshTokenRepository.find({
+          where: { user: { id: userId }, isRevoked: false },
+          order: { createdAt: 'ASC' },
+          take: tokenCount - maxTokens + 1,
+        });
+
+        await this.refreshTokenRepository.update(
+          { id: In(oldestTokens.map((t) => t.id)) },
+          { isRevoked: true },
+        );
+      }
+    } catch {
+      // Silent error handling for simplicity
+    }
   }
 }

--- a/src/auth/dto/refresh-token.dto.ts
+++ b/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,12 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RefreshTokenDto {
+  @ApiProperty({
+    description: 'Refresh token',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  @IsString()
+  @IsNotEmpty()
+  refreshToken: string;
+}

--- a/src/auth/dto/token-response.dto.ts
+++ b/src/auth/dto/token-response.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class TokenResponseDto {
+  @ApiProperty({
+    description: 'JWT access token',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  access_token: string;
+
+  @ApiProperty({
+    description: 'Refresh token for obtaining new access tokens',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  refresh_token: string;
+
+  @ApiProperty({
+    description: 'Token type',
+    example: 'Bearer',
+  })
+  token_type: string;
+
+  @ApiProperty({
+    description: 'Access token expiration time in seconds',
+    example: 900,
+  })
+  expires_in: number;
+}

--- a/src/auth/entities/refresh-token.entity.ts
+++ b/src/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('refresh_tokens')
+@Index(['token'], { unique: true })
+export class RefreshToken {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ type: 'varchar', length: 255, unique: true })
+  token: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column({ type: 'timestamp' })
+  expiresAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ type: 'boolean', default: false })
+  isRevoked: boolean;
+}

--- a/src/migrations/1757586625088-CreateRefreshTokensTable.ts
+++ b/src/migrations/1757586625088-CreateRefreshTokensTable.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreateRefreshTokensTable1757586625088 implements MigrationInterface {
+    name = 'CreateRefreshTokensTable1757586625088'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "refresh_tokens" ("id" SERIAL NOT NULL, "token" character varying(255) NOT NULL, "expiresAt" TIMESTAMP NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "isRevoked" boolean NOT NULL DEFAULT false, "userAgent" character varying(255), "ipAddress" inet, "userId" integer, CONSTRAINT "UQ_4542dd2f38a61354a040ba9fd57" UNIQUE ("token"), CONSTRAINT "PK_7d8bee0204106019488c4c50ffa" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_4542dd2f38a61354a040ba9fd5" ON "refresh_tokens" ("token") `);
+        await queryRunner.query(`ALTER TABLE "refresh_tokens" ADD CONSTRAINT "FK_610102b60fea1455310ccd299de" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "refresh_tokens" DROP CONSTRAINT "FK_610102b60fea1455310ccd299de"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_4542dd2f38a61354a040ba9fd5"`);
+        await queryRunner.query(`DROP TABLE "refresh_tokens"`);
+    }
+
+}

--- a/src/migrations/1757832395648-UpdateRefreshTokenEntity.ts
+++ b/src/migrations/1757832395648-UpdateRefreshTokenEntity.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateRefreshTokenEntity1757832395648 implements MigrationInterface {
+    name = 'UpdateRefreshTokenEntity1757832395648'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "refresh_tokens" DROP COLUMN "userAgent"`);
+        await queryRunner.query(`ALTER TABLE "refresh_tokens" DROP COLUMN "ipAddress"`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "refresh_tokens" ADD "ipAddress" inet`);
+        await queryRunner.query(`ALTER TABLE "refresh_tokens" ADD "userAgent" character varying(255)`);
+    }
+
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -210,16 +210,6 @@ export class PostsController {
       },
     },
   })
-  @ApiForbiddenResponse({
-    description:
-      "Insufficient permissions or trying to edit another user's post",
-    schema: {
-      example: {
-        statusCode: HttpStatus.FORBIDDEN,
-        message: 'You can only edit your own posts',
-      },
-    },
-  })
   @ApiBadRequestResponse({
     description: 'Validation failed',
     schema: {
@@ -234,7 +224,7 @@ export class PostsController {
     },
   })
   @ApiNotFoundResponse({
-    description: 'Post not found',
+    description: 'Post not found or not accessible',
     schema: {
       example: {
         statusCode: HttpStatus.NOT_FOUND,
@@ -273,17 +263,16 @@ export class PostsController {
     },
   })
   @ApiForbiddenResponse({
-    description:
-      "Insufficient permissions or trying to delete another user's post",
+    description: 'Insufficient permissions (delete post permission required)',
     schema: {
       example: {
         statusCode: HttpStatus.FORBIDDEN,
-        message: 'You do not have permission to delete this post',
+        message: 'Forbidden resource',
       },
     },
   })
   @ApiNotFoundResponse({
-    description: 'Post not found',
+    description: 'Post not found or not accessible',
     schema: {
       example: {
         statusCode: HttpStatus.NOT_FOUND,


### PR DESCRIPTION
This pull request introduces a robust refresh token system for authentication and improves the security and consistency of error handling in the posts module. The most significant changes are the addition of refresh token support (including token rotation, revocation, and limiting concurrent tokens), the introduction of related database entities and migrations, and updates to the posts service to avoid leaking information about post existence or permissions.

**Authentication & Token Management:**

* Added refresh token support to the authentication flow, including endpoints for refreshing tokens and logging out, and returning both access and refresh tokens in a new `TokenResponseDto` format. 
* Introduced a `RefreshToken` entity and related TypeORM integration, including limiting the number of concurrent refresh tokens per user and handling token revocation and cleanup. 
* Added database migrations to create and update the `refresh_tokens` table. 
**Posts Module Security & Error Handling:**

* Updated the posts service to return a `NotFoundException` instead of a `ForbiddenException` when users attempt to edit or delete posts they do not own, preventing information leakage about post existence or permissions. 
* Adjusted API documentation in the posts controller for more accurate and consistent error responses. 